### PR TITLE
Current level stored client-side & level progression

### DIFF
--- a/html/index.js
+++ b/html/index.js
@@ -23,9 +23,9 @@ var walls, end;
 // Obstacles and enemies
 var obstacles;
 
-var collidingWall;
-
 var walled, grounded, direction, waitForMovement;
+
+var currentLevel;
 
 function setup() {
     createCanvas(WIDTH, HEIGHT);
@@ -51,11 +51,13 @@ function loadLevel(data) {
     };
     fetch("/getLevel", options)
     .then(res => res.json())
-    .then(resJSON => reset(resJSON));
+    .then(resJSON => {
+        currentLevel = resJSON;
+        reset(currentLevel);
+    });
 }
 
 function reset(res) {
-
     // Build from request response.
     for(var key in res) {
         if(res.hasOwnProperty(key)) {
@@ -219,7 +221,7 @@ function restartLevel() {
     obstacles.removeSprites();
     clearSprites();
     let data = { "id" : levelId };
-    loadLevel(data);
+    reset(currentLevel);
 }
 
 function levelEnd() {
@@ -229,8 +231,7 @@ function levelEnd() {
     text("GAME OVER", WIDTH / 2, HEIGHT / 2);
     updateSprites(false);
     clearSprites();
-    let data = { "id" : levelId};
-    // let data = { "id" : ++levelId };
+    let data = { "id" : ++levelId };
     loadLevel(data);
 }
 


### PR DESCRIPTION
In this commit:
* Request next level_id when reaching a level's end.
* Store current level locally to not bother the server.